### PR TITLE
Use current java version for bootstrap

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -51,7 +51,7 @@ task inflateRpmSpec {
                     release_id          : releaseId,
                     version_opt         : versionOpt,
                     debug_level         : correttoDebugLevel,
-                    boot_jdk_major_version : version.major.toInteger() - 1,
+                    boot_jdk_major_version : version.major.toInteger(),
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
                     additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}",
                     zlib_option: project.findProperty("corretto.zlib_option") ?: "system",


### PR DESCRIPTION
Update the build.gradle to use JDK21 for bootstrapping builds.