### PR TITLE
8316468: os::write incorrectly handles partial write

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1391,7 +1391,7 @@ bool os::write(int fd, const void *buf, size_t nBytes) {
     if (res == OS_ERR) {
       return false;
     }
-    buf = (void *)((char *)buf + nBytes);
+    buf = (void *)((char *)buf + res);
     nBytes -= res;
   }
 


### PR DESCRIPTION
This is a clean backport of [JDK-8316468: os::write incorrectly handles partial write](https://bugs.openjdk.org/browse/JDK-8316468), fixing a major regression in JDK 21. The patch is already delivered in upstream JDK 21u, and targeted for 21.0.2. But I believe we need to get this fix sooner.

The risk for this fix is low: the fix is simple and (arguably) (obviously) correct.
