### PR TITLE
Use version format of the "update release"

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -7,7 +7,7 @@ UPSTREAM_REMOTE=$1
 # Load the current OpenJDK version
 source make/conf/version-numbers.conf
 
-BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}+ | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
+BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE} | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
 
 # Load the current Corretto version
 CURRENT_VERSION=$(cat version.txt)


### PR DESCRIPTION
Clean forward port of https://github.com/corretto/corretto-20/pull/16 to corretto-21. This change is for update release only.