### PR TITLE
8311130: AArch64: Sync SVE related CPU features with VM options

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2302,7 +2302,7 @@ const bool Matcher::match_rule_supported(int opcode) {
       break;
     case Op_ExpandBits:
     case Op_CompressBits:
-      if (!(UseSVE > 1 && VM_Version::supports_svebitperm())) {
+      if (!VM_Version::supports_svebitperm()) {
         ret_value = false;
       }
       break;

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -216,13 +216,13 @@ source %{
         }
         break;
       case Op_VectorLongToMask:
-        if (UseSVE < 2 || vlen > 64 || !VM_Version::supports_svebitperm()) {
+        if (vlen > 64 || !VM_Version::supports_svebitperm()) {
           return false;
         }
         break;
       case Op_CompressBitsV:
       case Op_ExpandBitsV:
-        if (UseSVE < 2 || !VM_Version::supports_svebitperm()) {
+        if (!VM_Version::supports_svebitperm()) {
           return false;
         }
         break;

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -206,13 +206,13 @@ source %{
         }
         break;
       case Op_VectorLongToMask:
-        if (UseSVE < 2 || vlen > 64 || !VM_Version::supports_svebitperm()) {
+        if (vlen > 64 || !VM_Version::supports_svebitperm()) {
           return false;
         }
         break;
       case Op_CompressBitsV:
       case Op_ExpandBitsV:
-        if (UseSVE < 2 || !VM_Version::supports_svebitperm()) {
+        if (!VM_Version::supports_svebitperm()) {
           return false;
         }
         break;

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -151,6 +151,10 @@ enum Ampere_CPU_Model {
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
 
+  static bool model_is(int cpu_model) {
+    return _model == cpu_model || _model2 == cpu_model;
+  }
+
   static bool is_zva_enabled() { return 0 <= _zva_length; }
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");

--- a/test/hotspot/jtreg/compiler/arguments/TestSyncCPUFeaturesWithSVEFlags.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestSyncCPUFeaturesWithSVEFlags.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8311130
+ * @summary Test synchronization between SVE arguments and CPU features
+ *
+ * @requires os.arch == "aarch64" & vm.compiler2.enabled
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller
+ *             jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:UseSVE=0
+ *                   compiler.arguments.TestSyncCPUFeaturesWithSVEFlags
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:UseSVE=1
+ *                   compiler.arguments.TestSyncCPUFeaturesWithSVEFlags
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:UseSVE=2
+ *                   compiler.arguments.TestSyncCPUFeaturesWithSVEFlags
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:MaxVectorSize=8
+ *                   compiler.arguments.TestSyncCPUFeaturesWithSVEFlags
+ */
+
+package compiler.arguments;
+
+import java.util.List;
+import java.util.Arrays;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestSyncCPUFeaturesWithSVEFlags {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) {
+        int sve_level = WB.getUintVMFlag("UseSVE").intValue();
+        List<String> features = Arrays.asList(WB.getCPUFeatures().split(", "));
+        boolean has_sve = features.contains("sve");
+        boolean has_sve2 = features.contains("sve2");
+        switch (sve_level) {
+            case 0: {
+                // No sve and sve2
+                Asserts.assertFalse(has_sve);
+                Asserts.assertFalse(has_sve2);
+                break;
+            }
+            case 1: {
+                // Only has sve, no sve2
+                Asserts.assertTrue(has_sve);
+                Asserts.assertFalse(has_sve2);
+                break;
+            }
+            case 2: {
+                // Has both sve and sve2
+                Asserts.assertTrue(has_sve);
+                Asserts.assertTrue(has_sve2);
+                break;
+            }
+            default: {
+                // Should not reach here
+                Asserts.assertTrue(false);
+                break;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
@@ -30,8 +30,7 @@
  * @requires (((os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64") &
  *            (vm.cpu.features ~= ".*bmi2.*" & vm.cpu.features ~= ".*bmi1.*" &
  *             vm.cpu.features ~= ".*sse2.*")) |
- *            ((vm.opt.UseSVE == "null" | vm.opt.UseSVE > 1) &
- *             os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*"))
+ *            (os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*"))
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestBitShuffleOpers
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 * @summary Test vectorization of numberOfTrailingZeros/numberOfLeadingZeros for Long
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestNumberOfContinuousZeros
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopulateIndex
 */


### PR DESCRIPTION
Clean backport of [JDK-8311130](https://bugs.openjdk.org/browse/JDK-8311130) which is needed for backports of:
- https://bugs.openjdk.org/browse/JDK-8321025 "Enable Neoverse N1 optimizations for Neoverse V2"
- https://bugs.openjdk.org/browse/JDK-8321105 "Enable UseCryptoPmullForCRC32 for Neoverse V2"