### PR TITLE
Fix AL jre alternative path

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -322,7 +322,7 @@ if [ \$1 -eq 1 ] ; then
 
   # Need to setup the jre alternatives separately when there is a higher priority jre java these don't get created above.
   alternatives --install %{_jvmdir}/jre-%{java_major_version} jre_%{java_major_version} %{java_home} %{alternatives_priority} \
-               --slave %{_jvmdir}/jre-%{java_major_version}-openjdk jre_%{java_major_version}_openjdk %{java_home}/jre
+               --slave %{_jvmdir}/jre-%{java_major_version}-openjdk jre_%{java_major_version}_openjdk %{java_home}
 fi
 
 %post devel


### PR DESCRIPTION
Built AL2023 locally and path is correct now
bash-5.2# ls -l /etc/alternatives/
total 8
lrwxrwxrwx 1 root root 52 Mar 25 20:06 java -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/bin/java
lrwxrwxrwx 1 root root 43 Mar 25 20:06 java-21-amazon-corretto -> /usr/lib/jvm/java-21-amazon-corretto.x86_64
lrwxrwxrwx 1 root root 59 Mar 25 20:06 java.1 -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/man/man1/java.1
lrwxrwxrwx 1 root root 43 Mar 25 20:06 jre -> /usr/lib/jvm/java-21-amazon-corretto.x86_64
lrwxrwxrwx 1 root root 43 Mar 25 20:06 jre_21 -> /usr/lib/jvm/java-21-amazon-corretto.x86_64
lrwxrwxrwx 1 root root 43 Mar 25 20:06 jre_21_openjdk -> /usr/lib/jvm/java-21-amazon-corretto.x86_64
lrwxrwxrwx 1 root root 43 Mar 25 20:06 jre_openjdk -> /usr/lib/jvm/java-21-amazon-corretto.x86_64
lrwxrwxrwx 1 root root 55 Mar 25 20:06 keytool -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/bin/keytool
lrwxrwxrwx 1 root root 62 Mar 25 20:06 keytool.1 -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/man/man1/keytool.1
lrwxrwxrwx 1 root root 34 Mar 21 02:00 libnssckbi.so.x86_64 -> /usr/lib64/pkcs11/p11-kit-trust.so
lrwxrwxrwx 1 root root 59 Mar 25 20:06 rmiregistry -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/bin/rmiregistry
lrwxrwxrwx 1 root root 66 Mar 25 20:06 rmiregistry.1 -> /usr/lib/jvm/java-21-amazon-corretto.x86_64/man/man1/rmiregistry.1

