### PR TITLE
Update nightly refresh workflow to avoid merge conflicts in version.txt

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -36,12 +36,16 @@ jobs:
               shell: bash
               run: |
                 git checkout nightly
+                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
+                git commit -m "Automerged version.txt from $LOCAL_BRANCH to nightly" || true
                 git merge origin/$LOCAL_BRANCH
                 git push origin nightly
             - name: "Merge Corretto-21 develop to lilliput"
               shell: bash
               run: |
                 git checkout lilliput
+                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
+                git commit -m "Automerged version.txt from $LOCAL_BRANCH to lilliput" || true
                 git merge origin/$LOCAL_BRANCH
                 git push origin lilliput
             - name: "Merge openjdk/shenandoah-jdk21u:master to generational-shenandoah"
@@ -55,5 +59,7 @@ jobs:
               shell: bash
               run: |
                 git checkout $LOCAL_SHENANDOAH
+                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
+                git commit -m "Automerged version.txt from $LOCAL_BRANCH to $LOCAL_SHENANDOAH" || true
                 git merge origin/$LOCAL_BRANCH
                 git push origin $LOCAL_SHENANDOAH


### PR DESCRIPTION
### Description
Pulls updated `version.txt` file from the `develop` branch into `nightly`, `lilliput`, and `generational-shenandoah` branches before performing the merge.

### Motivation and context
This will circumvent a merge conflict on `version.txt`.

### How has this been tested?
I ran this GitHub Action in my own forked repo, as well as testing the mechanism locally.
