### PR TITLE
Elide version.txt sync when merging develop into nightly

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -8,6 +8,7 @@ env:
   UPSTREAM_SHENANDOAH: https://github.com/openjdk/shenandoah-jdk21u
   LOCAL_BRANCH: develop
   LOCAL_SHENANDOAH: generational-shenandoah
+
 jobs:
     refresh-jdk:
         runs-on: ubuntu-latest
@@ -19,27 +20,35 @@ jobs:
               with:
                 fetch-depth: 0
                 ref: ${{ env.LOCAL_BRANCH }}
+
             - name: "Configure the user"
               run: |
                 git config user.email "no-reply@amazon.com"
                 git config user.name "corretto-github-robot"
+
             - name: "Merge openjdk/jdk:master to the corretto-21:develop"
               run: |
                 git fetch $UPSTREAM_REMOTE master || exit 1
                 git merge -m "Merge upstream-jdk" FETCH_HEAD
+
             - name: "Update Corretto version"
               shell: bash
               run: bash ./.github/scripts/update-version.sh $UPSTREAM_REMOTE
+
             - name: "Push to the corretto-21"
               run: git push origin $LOCAL_BRANCH
+
             - name: "Merge Corretto-21 develop to nightly"
               shell: bash
               run: |
                 git checkout nightly
                 git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
-                git commit -m "Automerged version.txt from $LOCAL_BRANCH to nightly" || true
+                git commit --allow-empty -m "Ephemeral commit: Automerged version.txt from $LOCAL_BRANCH to nightly"
+                ephemeral_commit=$(git rev-parse HEAD)
                 git merge origin/$LOCAL_BRANCH
+                git rebase --onto ${ephemeral_commit}^ ${ephemeral_commit}
                 git push origin nightly
+
             - name: "Merge Corretto-21 develop to lilliput"
               shell: bash
               run: |
@@ -48,6 +57,7 @@ jobs:
                 git commit -m "Automerged version.txt from $LOCAL_BRANCH to lilliput" || true
                 git merge origin/$LOCAL_BRANCH
                 git push origin lilliput
+
             - name: "Merge openjdk/shenandoah-jdk21u:master to generational-shenandoah"
               shell: bash
               run: |
@@ -55,6 +65,7 @@ jobs:
                 git fetch $UPSTREAM_SHENANDOAH master || exit 1
                 git merge -m "Merge upstream shenandoah" FETCH_HEAD
                 git push origin $LOCAL_SHENANDOAH
+
             - name: "Merge Corretto-21 develop to generational-shenandoah"
               shell: bash
               run: |


### PR DESCRIPTION
### Description

Before merging develop into `nightly`, sync `version.txt` with develop to avoid a merge conflict; afterward, remove this sync commit.

The reason for removing the commit afterward is that we run `update-version.sh`, which rewrites the file as necessary. Since `nightly` merges from both `jdk21u` and `jdk21-dev`, but `develop` only merges from jdk21u, version.txt may be newer in `nightly`. If we sync `version.txt` with `develop` and don't remove it, as we do currently, we avoid the merge conflict, but then `update-version.sh` (which we treat as authoritative) overwrites `version.txt`, and we have the two mechanisms writing two new commits each time the action is run.

### Motivation and context

The goal is to avoid merge conflicts in `version.txt` during automated merges between upstream repos and various branches. However, this proves to be slightly complex due to the flow of the code. The current technique of simply copying `version.txt` from `develop` into `nightly` can result in an incorrect version of the file being written, which is later corrected by `update-version.sh`. There may be a cleaner way to avoid the merge conflict than simply copying the file, writing a (possibly empty) commit, doing the merge, and then removing the commit with a rebase before pushing it. If you know of one, please suggest it.

### How has this been tested?

Tested in a forked repo, as well as on the command line.