### PR TITLE
Remove clean target in Windows builds

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -54,7 +54,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir buildRoot
 
-    commandLine 'make', 'clean', 'images', 'test-image'
+    commandLine 'make', 'images', 'test-image'
 }
 
 task copyImage(type: Copy) {


### PR DESCRIPTION
`clean` target in Windows builds caused issues and is unnecessary when building.