### PR TITLE
8349705: java.net.URI.scanIPv4Address throws unnecessary URISyntaxException

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3479,7 +3479,7 @@ public final class URI
                 if (q < m) break;
                 return q;
             }
-            fail("Malformed IPv4 address", q);
+            if (strict) fail("Malformed IPv4 address", q);
             return -1;
         }
 
@@ -3508,12 +3508,16 @@ public final class URI
                 return -1;
             }
 
+            if (p == -1) {
+                return p;
+            }
+
             if (p > start && p < n) {
                 // IPv4 address is followed by something - check that
                 // it's a ":" as this is the only valid character to
                 // follow an address.
                 if (input.charAt(p) != ':') {
-                    p = -1;
+                    return -1;
                 }
             }
 


### PR DESCRIPTION
### Description
Clean backport of [JDK-8349705](https://bugs.openjdk.org/browse/JDK-8349705): java.net.URI.scanIPv4Address throws unnecessary URISyntaxException

### Related issues
 [JDK-8349705](https://bugs.openjdk.org/browse/JDK-8349705)

### Motivation and context
Performance improvement,  we have seem this  in multiple internal services profiler data, there were two service teams asking for the fix to be backported. 

### How has this been tested?
* GHA passed
* JDK-8349705 is in mainline for over two months, no issue so far.

