### PR TITLE
Test `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` fails on 32 bit systems

### DIFF
--- a/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package gc;
 /* @test TestObjectAlignmentCardSize.java
  * @summary Test to check correct handling of ObjectAlignmentInBytes and GCCardSizeInBytes combinations
  * @requires vm.gc != "Z"
+ * @requires vm.bits == "64"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run driver gc.TestObjectAlignmentCardSize


### PR DESCRIPTION
Cherry-picking change to only run `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` on 64 bit systems. Relevant JBS issue: https://bugs.openjdk.org/browse/JDK-8367372.

Test is relatively trivial and change has been tested in upstream.