### PR TITLE
8367131: Test com/sun/jdi/ThreadMemoryLeakTest.java fails on 32 bits

### DIFF
--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -28,7 +28,7 @@
  *
  * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations.
  *          Require compressed oops because not doing so increases memory usage.
- * @requires (vm.compMode == "Xmixed") & vm.opt.final.UseCompressedOops
+ * @requires (vm.compMode == "Xmixed") & (vm.bits == 32 | vm.opt.final.UseCompressedOops)
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
  * @comment run with -Xmx7m so any leak will quickly produce OOME


### PR DESCRIPTION
Clean backport from jdk21u-dev to corretto-21. Fix for the test bug. Tested on Linux ARM 32/64-bit.
PR in upstream: https://github.com/openjdk/jdk21u-dev/pull/2204