### PR TITLE
Set OnSpinWaitInst to SB for Graviton 4

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -230,7 +230,11 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      if (model_is(0xd4f)) {
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "sb");
+      } else {
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      }
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {


### PR DESCRIPTION
A clean backport of https://github.com/corretto/corretto-25/commit/4eaa1ec50b3b58e92f31ce72a4e689aa66836c4e

Graviton 4 is Neoverse-V2. SB-based spin pauses are less disruptive then ISB-based ones on Neoverse-V2.

This PR sets the default value for the OnSpinWaitInst flag to `sb` if the CPU model matches 0xd4f (Neoverse-V2); otherwise, it remains `isb`.
