### PR TITLE
Don't set OnSpinWaitInst to SB if VM_Version does not support it

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -230,7 +230,7 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      if (model_is(0xd4f)) {
+      if (model_is(0xd4f) && VM_Version::supports_sb()) {
         FLAG_SET_DEFAULT(OnSpinWaitInst, "sb");
       } else {
         FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");


### PR DESCRIPTION
When we run java on Graviton 4 with AL2 kernel 4.14, it fails with:
```
OnSpinWaitInst is SB but current CPU does not support SB instruction
```

This happens because AArch64 kernel 4.14 does not support HWCAP_SB. The corresponding bit is always set to 0.

This PR fixes the failure. In addition to checking a CPU model, we check if OS supports `sb` on this CPU.