### PR TITLE
Fix tier2 test failures by blacklisting asprof and jfrconv tools

### DIFF
--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -64,7 +64,10 @@ public class HelpFlagsTest extends TestHelper {
         "jmc",
         "jweblauncher",
         "jcontrol",
-        "ssvagent"
+        "ssvagent",
+        // asprof don't test
+        "asprof",
+        "jfrconv"
     };
 
     // Lists which tools support which flags.

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -44,6 +44,7 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
     static final String[] BLACKLIST_JOPTION = {
+        "asprof",
         "controlpanel",
         "jabswitch",
         "java-rmi",
@@ -57,6 +58,7 @@ public class VersionCheck extends TestHelper {
         "javaw",
         "javaws",
         "jcontrol",
+        "jfrconv",
         "jmc",
         "jmc.ini",
         "jweblauncher",
@@ -68,6 +70,7 @@ public class VersionCheck extends TestHelper {
     // tools that do not accept -version
     static final String[] BLACKLIST_VERSION = {
         "appletviewer",
+        "asprof",
         "controlpanel",
         "jaccessinspector",
         "jaccessinspector-32",
@@ -86,6 +89,7 @@ public class VersionCheck extends TestHelper {
         "jdeprscan",
         "jdeps",
         "jfr",
+        "jfrconv",
         "jimage",
         "jinfo",
         "jlink",


### PR DESCRIPTION
### Description

Fix tier2 test failures by blacklisting asprof and jfrconv tools.

Confirmed fixes the two tests
- `tools/launcher/VersionCheck.java`
- `tools/launcher/HelpFlagsTest.java`