### PR TITLE
Scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,10 @@ on:
         description: 'Additional make arguments'
         required: false
 
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/refresh-jdk-dev.yml
+++ b/.github/workflows/refresh-jdk-dev.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 9 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 env:
   UPSTREAM_REMOTE: https://github.com/openjdk/jdk21u-dev
   LOCAL_BRANCH: nightly

--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 env:
   UPSTREAM_REMOTE: https://github.com/openjdk/jdk21u
   UPSTREAM_SHENANDOAH: https://github.com/openjdk/shenandoah-jdk21u


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description

This PR reduces GitHub Token permissions to least necessary.

### Related issues


### Motivation and context

Improve GitHub Actions security posture.

### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
