### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -41,6 +41,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-cross-compile:
     name: build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -62,6 +62,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     name: build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,6 +55,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     name: build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,6 +60,9 @@ env:
   MSYS2_PATH_TYPE: minimal
   CHERE_INVOKING: 1
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   ###

--- a/.github/workflows/refresh-jdk-dev.yml
+++ b/.github/workflows/refresh-jdk-dev.yml
@@ -6,6 +6,9 @@ on:
 env:
   UPSTREAM_REMOTE: https://github.com/openjdk/jdk21u-dev
   LOCAL_BRANCH: nightly
+permissions:
+  contents: write
+
 jobs:
     refresh-jdk:
         runs-on: ubuntu-latest

--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -9,6 +9,9 @@ env:
   LOCAL_BRANCH: develop
   LOCAL_SHENANDOAH: generational-shenandoah
 
+permissions:
+  contents: write
+
 jobs:
     refresh-jdk:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ env:
   MSYS2_PATH_TYPE: minimal
   CHERE_INVOKING: 1
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.