### PR TITLE
Keep symlinks in legal subdirectories in linux/macos packages. Remove root legal files that already exist in legal/java.base

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ allprojects {
 
         // If this is a certified release build, exclude the README.JAVASE file
         excludeReadmeJavaSE = Boolean.parseBoolean(project.findProperty("corretto.excludeReadmeJavaSE"))
-        rootFiles = ['ADDITIONAL_LICENSE_INFO', 'ASSEMBLY_EXCEPTION', 'LICENSE', 'README.md', 'commitId.txt', 'version.txt']
+        rootFiles = ['README.md', 'commitId.txt', 'version.txt']
         if (!excludeReadmeJavaSE) {
             rootFiles += 'README.JAVASE'
         }
@@ -137,6 +137,8 @@ allprojects {
         // If asyncProfilerBinariesPath provided, store for easy reference when bundling
         asyncProfilerBinariesPath = project.findProperty("asyncProfilerBinariesPath") ?: ""
         asyncProfilerLegal = "${rootDir}/installers/legal/async-profiler.md"
+
+        keepSymlinks = Boolean.parseBoolean(project.findProperty("corretto.keepSymlinks"))
 
         // Valid value: null, release, debug, fastdebug, slowdebug
         correttoDebugLevel = "release" // Default: release
@@ -340,5 +342,20 @@ project(':openjdksrc') {
 
     artifacts {
         archives sourceDistributionTarball
+    }
+}
+
+def runCmdAndLog(Project project, List<String> args) {
+    def output = new ByteArrayOutputStream()
+    def result = project.exec {
+        commandLine args
+        standardOutput = output
+        errorOutput = output
+        ignoreExitValue = true
+    }
+
+    project.logger.info("OUTPUT:\n${output}")
+    if (result.exitValue != 0) {
+        throw new GradleException("Command '${args.join("' '")}' failed with exit code ${result.exitValue}")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -354,8 +354,10 @@ def runCmdAndLog(Project project, List<String> args) {
         ignoreExitValue = true
     }
 
-    project.logger.info("OUTPUT:\n${output}")
     if (result.exitValue != 0) {
-        throw new GradleException("Command '${args.join("' '")}' failed with exit code ${result.exitValue}")
+        project.logger.error("ERROR: command failed with exit code ${result.exitValue}:\n${args.join(" ")}\nOUTPUT:\n${output}")
+        throw new GradleException("Command '${args.join("' '")}' failed with exit code=${result.exitValue}")
+    } else {
+        project.logger.info("Command output:\n${output}")
     }
 }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -127,6 +127,7 @@ BuildRequires: make
 BuildRequires: alsa-lib-devel
 BuildRequires: binutils
 BuildRequires: which
+BuildRequires: bsdtar
 BuildRequires: cups-devel
 BuildRequires: fontconfig-devel
 BuildRequires: freetype-devel

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -181,13 +181,13 @@ task packageBuildResults {
             output=`realpath "$outputTarFile"`
             rm -f "\$output.gz"
             pushd "$buildRoot"
-            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption "${rootFilesNoLegal.join('" "')}"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption bin conf include jmods lib man/man1 release
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1 release
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption legal
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal
             popd
             gzip -9 "\$output"
         """

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -171,9 +171,9 @@ task packageBuildResults {
     inputs.dir(jdkResultingImage)
     outputs.file("${outputTarFile}.gz")
 
-    def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
-
     doLast {
+        def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
+
         // -s option adds prefix to each file name, but not to symlink targets (S modifier)
         def script = """
             set -ex

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -153,36 +153,49 @@ task packageDebugSymbols(type: Tar) {
     }
 }
 
-task packageBuildResults(type: Tar) {
+task packageBuildResults {
     description 'Compresses the JDK image and puts the results in build/distributions.'
     dependsOn packageDebugSymbols
     dependsOn executeBuild
     dependsOn bundleThirdPartyBinaries
-    archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
-    compression Compression.GZIP
-    from(buildRoot) {
-        include project.rootFiles
-    }
-    from(jdkResultingImage) {
-        include 'bin/**'
-        include 'conf/**'
-        include 'include/**'
-        include 'jmods/**'
-        include 'lib/**'
-        include 'man/man1/**'
-        include 'release'
-        exclude '**/*.diz'
-    }
 
-    // Copy legal directory specifically to set permission correctly.
-    // See https://github.com/corretto/corretto-11/issues/129
-    from(jdkResultingImage) {
-        include 'legal/**'
-        fileMode 0444
+    def jdkArchiveName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
+    def outputTarFile = "${distributionDir}/${jdkArchiveName}.tar"
+    def prefix = jdkArchiveName
+
+    // Omit legal files in the root of the package
+    def javaBaseLegalFiles = file("$jdkResultingImage/legal/java.base").listFiles().findAll { it.isFile() }.collect { it.name };
+    def rootFilesNoLegal = project.rootFiles.findAll { !(it in javaBaseLegalFiles) }
+
+    inputs.files(rootFilesNoLegal)
+    inputs.dir(jdkResultingImage)
+    outputs.file("${outputTarFile}.gz")
+
+    def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
+
+    doLast {
+        // -s option adds prefix to each file name, but not to symlink targets (S modifier)
+        def script = """
+            set -ex
+
+            output=`realpath "$outputTarFile"`
+            rm -f "\$output.gz"
+            pushd "$buildRoot"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption "${rootFilesNoLegal.join('" "')}"
+            popd
+            pushd "$jdkResultingImage"
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption bin conf include jmods lib man/man1 release
+            find legal -type f | xargs -n100 chmod 444
+            find legal -type d | xargs -n100 chmod 755
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption legal
+            popd
+            gzip -9 "\$output"
+        """
+
+        runCmdAndLog(project, ['bash', '-c', script])
     }
-    into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }
 
 artifacts {
-    archives packageBuildResults
+    archives file: packageBuildResults.outputs.files.singleFile, builtBy: packageBuildResults
 }

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -77,12 +77,16 @@ ospackage {
 
 /**
  * Uncompress and copy the universal Corretto artifact
- * tar for DEB packaging.
+ * tar for DEB packaging via external tar to correctly handle symlinks.
  */
-task extractUniversalTar(type: Copy) {
+task extractUniversalTar(type: Exec) {
     dependsOn project.configurations.compile
-    from tarTree(project.configurations.compile.singleFile)
-    into buildRoot
+
+    inputs.file project.configurations.compile.singleFile
+    outputs.dir jdkBinaryDir
+
+    workingDir buildRoot
+    commandLine 'tar', 'xvf', project.configurations.compile.singleFile
 }
 
 /**

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -69,12 +69,16 @@ ospackage {
 
 /**
  * Uncompress and copy the universal Corretto artifact
- * tar for RPM packaging.
+ * tar for RPM packaging. Use native tar to correctly handle symlinks.
  */
-task extractUniversalTar(type: Copy) {
+task extractUniversalTar(type: Exec) {
     dependsOn project.configurations.compile
-    from tarTree(project.configurations.compile.singleFile)
-    into buildRoot
+
+    inputs.file project.configurations.compile.singleFile
+    outputs.dir jdkBinaryDir
+
+    workingDir buildRoot
+    commandLine 'tar', 'xvf', project.configurations.compile.singleFile
 }
 
 /**

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -159,9 +159,9 @@ task packageBuildResults {
     inputs.dir(jdkResultingImage)
     outputs.file("${outputTarFile}.gz")
 
-    def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
-
     doLast {
+        def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
+
         // -s option adds prefix to each file name, but not to symlink targets (S modifier)
         def script = """
             set -ex

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -143,37 +143,47 @@ task packageDebugSymbols(type: Tar) {
     }
 }
 
-task packageBuildResults(type: Tar) {
+task packageBuildResults {
     description 'Compresses the JDK image and puts the results in build/distributions.'
     dependsOn packageDebugSymbols
     dependsOn bundleThirdPartyBinaries
-    archiveName "${project.correttoJdkArchiveName}.tar.gz"
-    compression Compression.GZIP
-    from(buildRoot) {
-        include project.rootFiles
-        into project.correttoJdkArchiveName
-    }
-    from(jdkResultingImage) {
-        include 'bin/**'
-        include 'conf/**'
-        include 'include/**'
-        include 'jmods/**'
-        include 'lib/**'
-        include 'man/man1/**'
-        include 'release'
-        exclude '**/*.diz'
-        into project.correttoJdkArchiveName
-    }
 
-    // Copy legal directory specifically to set permission correctly.
-    // See https://github.com/corretto/corretto-11/issues/129
-    from("${jdkResultingImage}/legal") {
-        include '**'
-        fileMode 0444
-        into "${project.correttoJdkArchiveName}/legal"
+    def outputTarFile = "${distributionDir}/${project.correttoJdkArchiveName}.tar"
+    def prefix = project.correttoJdkArchiveName
+
+    // Omit legal files in the root of the package
+    def javaBaseLegalFiles = file("$jdkResultingImage/legal/java.base").listFiles().findAll { it.isFile() }.collect { it.name };
+    def rootFilesNoLegal = project.rootFiles.findAll { !(it in javaBaseLegalFiles) }
+
+    inputs.files(rootFilesNoLegal)
+    inputs.dir(jdkResultingImage)
+    outputs.file("${outputTarFile}.gz")
+
+    def tarSymlinkOption = project.keepSymlinks ? '' : '-L'
+
+    doLast {
+        // -s option adds prefix to each file name, but not to symlink targets (S modifier)
+        def script = """
+            set -ex
+
+            output=`realpath "$outputTarFile"`
+            rm -f "\$output.gz"
+            pushd "$buildRoot"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption "${rootFilesNoLegal.join('" "')}"
+            popd
+            pushd "$jdkResultingImage"
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption bin conf include jmods lib man/man1
+            find legal -type f | xargs -n100 chmod 444
+            find legal -type d | xargs -n100 chmod 755
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption legal
+            popd
+            gzip -9 "\$output"
+        """
+
+        runCmdAndLog(project, ['bash', '-c', script])
     }
 }
 
 artifacts {
-    archives packageBuildResults
+    archives file: packageBuildResults.outputs.files.singleFile, builtBy: packageBuildResults
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -169,13 +169,13 @@ task packageBuildResults {
             output=`realpath "$outputTarFile"`
             rm -f "\$output.gz"
             pushd "$buildRoot"
-            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption "${rootFilesNoLegal.join('" "')}"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption bin conf include jmods lib man/man1
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption legal
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal
             popd
             gzip -9 "\$output"
         """

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -144,7 +144,6 @@ task prepareArtifacts {
                 include "Contents/Home/conf/**"
                 include "Contents/Home/include/**"
                 include "Contents/Home/jmods/**"
-                include "Contents/Home/legal/**"
                 include "Contents/Home/lib/**"
                 include "Contents/Home/man/man1/**"
                 include "Contents/Home/release"
@@ -158,6 +157,13 @@ task prepareArtifacts {
             }
             into "${buildDir}/${correttoMacDir}"
         }
+
+        // cp preserves symlinks
+        def cpOptions = project.keepSymlinks ? '-R' : '-RL'
+        exec {
+            commandLine 'cp', cpOptions, "${jdkResultingImage}/${correttoMacDir}/Contents/Home/legal", "${buildDir}/${correttoMacDir}/Contents/Home/"
+        }
+
         // Set the directory as bundle
         exec {
             commandLine "SetFile", "-a", "B", "${buildDir}/${correttoMacDir}"


### PR DESCRIPTION
### Description
Symlinks in OpenJDK legal/ subtree are not respected by gradle build files and were replaced by files themselves, which accounted to around extra 2Mb in unarchived distribution. Also, duplicate legal files exist in the root of the package (`LICENSE`, `ASSEMBLY_EXCEPTION`, `ADDITIONAL_LICENSE_INFO`).

For all Linux and MacOS targets, the Gradle build files were modified to allow keeping symlinks already created by OpenJDK jlink during the build process.

By default, symlinks are dereferenced as they used to be. However, when Gradle is invoked with `-Pcorretto.keepSymlinks=true` flag, the symlinks are kept as symlinks in the produced *.tar.gz, *.deb, *.rpm, *.pkg distribution files. 

Note that due to a bug/misfeature with -h option in GNU tar, I had to use bsdtar for creating archives either with or without symlinks, so the Docker images now require bsdtar to be installed. Its package can be named 'bsdtar' or 'libarchive-tools' in different OS

### Motivation and context
Trying to reduce unpacked bundle size

### How has this been tested?
By building the following targets:

* installers:linux:apline:tar:build
* installers:linux:universal:tar:build
* installers:linux:universal:deb:build
* installers:linux:universal:rpm:build
* installers:mac:tar:build
* installers:mac:pkg:build
   
... and verifying that previously regular licence files are replaced with symlinks as in OpenJDK in the each type of packaging

### Platform information
Works on OS: Linux (universal), Alpine Linux, MacOS
Applies to version: 21, 25, tip