### PR TITLE
Fix nightly build linter by adding --with-version-date support to AL2 spec

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -50,6 +50,7 @@ task inflateRpmSpec {
                     build_id            : buildId,
                     release_id          : releaseId,
                     version_opt         : versionOpt,
+                    version_date        : project.findProperty("corretto.versionDate") ?: "%{nil}",
                     debug_level         : correttoDebugLevel,
                     boot_jdk_major_version : version.major.toInteger(),
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -26,6 +26,7 @@
 %global build_id        $build_id
 %global release_id      $release_id
 %global version_opt     $version_opt
+%global version_date    $version_date
 %global experimental_feature     $experimental_feature
 %global additional_configure_options     $additional_configure_options
 %global zlib_option $zlib_option
@@ -283,6 +284,9 @@ bash ./configure \\
         --with-libpng=system \\
         --with-zlib="%{zlib_option}" \\
         --with-version-opt="%{version_opt}" \\
+%if "%{version_date}" != "%{nil}"
+        --with-version-date="%{version_date}" \\
+%endif
         --with-version-build="%{build_id}" \\
         --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{build_id}.%{release_id}" \\
         --with-version-pre= \\


### PR DESCRIPTION
This PR fixes the linter issue for nightly builds on Amazon Linux by adding support for
--with-version-date parameter in the AL2 spec file.