### PR TITLE
Include /release file for generic linux

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -180,7 +180,7 @@ task packageBuildResults {
             bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFiles.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' bin conf include lib man/man1 release \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' release bin conf include lib man/man1 \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -168,7 +168,7 @@ task packageBuildResults {
             bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFiles.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' bin conf include lib man/man1 \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' release bin conf include lib man/man1 \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal


### PR DESCRIPTION
The file was excluded from generic linux package in commit 4b915d90d3f66f30bf140f194c052825d58ac3e8, restoring it back. 

Tested on generic linux-x86.