### PR TITLE
Recommend instead of Require dependencies for AL2023 headless

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -160,6 +160,12 @@ Requires: libXrandr
 Requires: libXtst
 Requires: giflib
 Requires: libpng
+Requires: fontconfig
+Requires: freetype
+Requires: dejavu-sans-fonts
+Requires: dejavu-serif-fonts
+Requires: dejavu-sans-mono-fonts
+Requires: alsa-lib
 # Require headless package.
 Requires: %{name}-headless%{?_isa} = %{epoch}:%{version}-%{release}
 
@@ -182,16 +188,22 @@ AutoReq: 0
 
 %if "%{dist}" == ".amzn2" || "%{dist}" == ".amzn2int"
 Requires: jpackage-utils
-%else
-Requires: javapackages-filesystem
-%endif
-Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: dejavu-sans-fonts
 Requires: dejavu-serif-fonts
 Requires: dejavu-sans-mono-fonts
 Requires: alsa-lib
+%else
+Requires: javapackages-filesystem
+Recommends: fontconfig
+Recommends: freetype
+Recommends: dejavu-sans-fonts
+Recommends: dejavu-serif-fonts
+Recommends: dejavu-sans-mono-fonts
+Recommends: alsa-lib
+%endif
+Requires: zlib
 Requires: libjpeg
 Requires: ca-certificates
 %if "%{dist}" == ".amzn2"


### PR DESCRIPTION
### Description
Backport of https://github.com/corretto/corretto-jdk/pull/163

### Related issues
https://github.com/amazonlinux/amazon-linux-2023/issues/940

### Motivation and context
See issue

### How has this been tested?
Tested the install of a internal build, and default behavior with the change remains the same
```
dnf localinstall java-25-amazon-corretto-<redacted>-headless-25.0.3+9-1.amzn2023.1.x86_64.rpm
Last metadata expiration check: 0:02:11 ago on Tue May  5 19:04:46 2026.
Dependencies resolved.
============================================================================================================================================================
 Package                                                          Architecture       Version                                 Repository                Size
============================================================================================================================================================
Installing:
 java-25-amazon-corretto-<redacted>-headless             x86_64             1:25.0.3+9-1.amzn2023.1                 @commandline             107 M
Installing dependencies:
 cairo                                                            x86_64             1.18.0-4.amzn2023.0.3                   amazonlinux              717 k
 chkconfig                                                        x86_64             1.15-2.amzn2023.0.2                     amazonlinux              161 k
 fonts-filesystem                                                 noarch             1:2.0.5-12.amzn2023.0.2                 amazonlinux              9.5 k
 google-noto-fonts-common                                         noarch             20240401-1.amzn2023.0.2                 amazonlinux               17 k
 google-noto-sans-vf-fonts                                        noarch             20240401-1.amzn2023.0.2                 amazonlinux              593 k
 graphite2                                                        x86_64             1.3.14-7.amzn2023.0.2                   amazonlinux               97 k
 harfbuzz                                                         x86_64             7.0.0-2.amzn2023.0.2                    amazonlinux              873 k
 javapackages-filesystem                                          noarch             6.0.0-7.amzn2023.0.6                    amazonlinux               12 k
 langpacks-core-font-en                                           noarch             3.0-21.amzn2023.0.4                     amazonlinux               10 k
 libX11                                                           x86_64             1.8.10-2.amzn2023.0.1                   amazonlinux              659 k
 libX11-common                                                    noarch             1.8.10-2.amzn2023.0.1                   amazonlinux              147 k
 libXau                                                           x86_64             1.0.11-6.amzn2023.0.1                   amazonlinux               33 k
 libXext                                                          x86_64             1.3.6-1.amzn2023.0.1                    amazonlinux               42 k
 libXrender                                                       x86_64             0.9.11-6.amzn2023.0.1                   amazonlinux               29 k
 libbrotli                                                        x86_64             1.0.9-4.amzn2023.0.2                    amazonlinux              315 k
 libjpeg-turbo                                                    x86_64             2.1.4-2.amzn2023.0.5                    amazonlinux              190 k
 libpng                                                           x86_64             2:1.6.37-10.amzn2023.0.12               amazonlinux              128 k
 libxcb                                                           x86_64             1.17.0-1.amzn2023.0.1                   amazonlinux              235 k
 pixman                                                           x86_64             0.43.4-1.amzn2023.0.4                   amazonlinux              296 k
 xml-common                                                       noarch             0.6.3-56.amzn2023.0.2                   amazonlinux               32 k
Installing weak dependencies:
 alsa-lib                                                         x86_64             1.2.7.2-1.amzn2023.0.3                  amazonlinux              503 k
 dejavu-sans-fonts                                                noarch             2.37-16.amzn2023.0.2                    amazonlinux              1.3 M
 dejavu-sans-mono-fonts                                           noarch             2.37-16.amzn2023.0.2                    amazonlinux              467 k
 dejavu-serif-fonts                                               noarch             2.37-16.amzn2023.0.2                    amazonlinux              1.0 M
 fontconfig                                                       x86_64             2.13.94-2.amzn2023.0.2                  amazonlinux              273 k
 freetype                                                         x86_64             2.13.2-5.amzn2023.0.2                   amazonlinux              422 k

Transaction Summary
============================================================================================================================================================
Install  27 Packages

Total size: 116 M
Total download size: 8.5 M
Installed size: 311 M
```
behavior of headful package with the change:
```
dnf localinstall java-25-amazon-corretto-<redacted>-25.0.3+9-1.amzn2023.1.x86_64.rpm
Last metadata expiration check: 0:01:18 ago on Tue May  5 19:15:02 2026.
Error: 
 Problem: conflicting requests
  - nothing provides java-25-amazon-corretto-<redacted>-headless(x86-64) = 1:25.0.3+9-1.amzn2023.1 needed by java-25-amazon-corretto-<redacted>-1:25.0.3+9-1.amzn2023.1.x86_64 from @commandline
(try to add '--skip-broken' to skip uninstallable packages)
```
with headless already installed:
```
dnf localinstall java-25-amazon-corretto-<redacted>-25.0.3+9-1.amzn2023.1.x86_64.rpm              
Last metadata expiration check: 0:04:24 ago on Tue May  5 19:15:02 2026.
Dependencies resolved.
============================================================================================================================================================
 Package                                                    Architecture          Version                                 Repository                   Size
============================================================================================================================================================
Installing:
 java-25-amazon-corretto-<redacted>                x86_64                1:25.0.3+9-1.amzn2023.1                 @commandline                244 k
Installing dependencies:
 giflib                                                     x86_64                5.2.1-9.amzn2023.0.3                    amazonlinux                  48 k
 libICE                                                     x86_64                1.1.1-3.amzn2023.0.1                    amazonlinux                  76 k
 libSM                                                      x86_64                1.2.4-3.amzn2023.0.1                    amazonlinux                  45 k
 libXi                                                      x86_64                1.8.2-1.amzn2023.0.1                    amazonlinux                  42 k
 libXinerama                                                x86_64                1.1.5-6.amzn2023.0.1                    amazonlinux                  16 k
 libXrandr                                                  x86_64                1.5.4-3.amzn2023.0.1                    amazonlinux                  29 k
 libXt                                                      x86_64                1.3.0-3.amzn2023.0.1                    amazonlinux                 183 k
 libXtst                                                    x86_64                1.2.5-1.amzn2023.0.1                    amazonlinux                  22 k

Transaction Summary
============================================================================================================================================================
Install  9 Packages

Total size: 705 k
Total download size: 461 k
Installed size: 1.7 M
```

### Platform information
    Works on OS: AL2023+


### Additional context
n/a