### PR TITLE
8343698: Linux x86_64 lto build gives a lot of warnings and fails lto-wrapper: fatal error: make returned 2 exit status

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -37,6 +37,10 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
     # Need extra inlining to collapse shared marking code into the hot marking loop
     BUILD_LIBJVM_shenandoahMark.cpp_CXXFLAGS := --param inline-unit-growth=1000
   endif
+  # disable lto in g1ParScanThreadState because of special inlining/flattening used there
+  ifeq ($(call check-jvm-feature, link-time-opt), true)
+    BUILD_LIBJVM_g1ParScanThreadState.cpp_CXXFLAGS := -fno-lto
+  endif
 endif
 
 LIBJVM_FDLIBM_COPY_OPT_FLAG := $(CXX_O_FLAG_NONE)


### PR DESCRIPTION
Backport of https://github.com/openjdk/jdk21u-dev/pull/2907 into Corretto 21 ahead of time for the upcoming July release.