### PR TITLE
Normalize legal files and directories for mac

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -164,6 +164,14 @@ task prepareArtifacts {
             commandLine 'cp', cpOptions, "${jdkResultingImage}/${correttoMacDir}/Contents/Home/legal", "${buildDir}/${correttoMacDir}/Contents/Home/"
         }
 
+        // Normalize legal file permissions to match the OpenJDK build output (read-only)
+        exec {
+            commandLine 'bash', '-c', "find ${buildDir}/${correttoMacDir}/Contents/Home/legal -type f | xargs -n100 chmod 444"
+        }
+        exec {
+            commandLine 'bash', '-c', "find ${buildDir}/${correttoMacDir}/Contents/Home/legal -type d | xargs -n100 chmod 755"
+        }
+
         // Set the directory as bundle
         exec {
             commandLine "SetFile", "-a", "B", "${buildDir}/${correttoMacDir}"


### PR DESCRIPTION
Noticed legal file and folder permissions for mac artifacts differ from linux. We're missing [these normalization commands](https://github.com/satyenme/corretto-jdk/blob/develop/installers/linux/universal/tar/build.gradle#L196-L197). Ensures that legal build artifacts are properly scoped.